### PR TITLE
Retry GitHub API calls

### DIFF
--- a/sbt-plugin/README.md
+++ b/sbt-plugin/README.md
@@ -4,4 +4,4 @@ An sbt plugin that can extract the dependencies of your project and submit them 
 
 It is not recommended and generally not useful to install this plugin manually, as it can only be used in a Github workflow.
 
-The easiest way to use this plugin is to set [scalacenter/sbt-dependency-submssion](https://github.com/scalacenter/sbt-dependency-submission) up in your Github workflow.
+The easiest way to use this plugin is to set [scalacenter/sbt-dependency-submission](https://github.com/scalacenter/sbt-dependency-submission) up in your Github workflow.

--- a/sbt-plugin/src/main/scala/ch/epfl/scala/AnalyzeDependencyGraph.scala
+++ b/sbt-plugin/src/main/scala/ch/epfl/scala/AnalyzeDependencyGraph.scala
@@ -4,13 +4,15 @@ import java.nio.file.Paths
 
 import scala.Console
 import scala.concurrent.Await
-import scala.concurrent.duration.Duration
 import scala.sys.process._
 import scala.util.Failure
 import scala.util.Properties
 import scala.util.Success
 import scala.util.Try
 
+import ch.epfl.scala.ApiCall.ServerError
+import ch.epfl.scala.ApiCall.retryOnServerError
+import ch.epfl.scala.ApiCall.timeout
 import ch.epfl.scala.GithubDependencyGraphPlugin.autoImport._
 import ch.epfl.scala.githubapi._
 import gigahorse.FullResponse
@@ -86,17 +88,21 @@ object AnalyzeDependencyGraph {
     }
 
   private def downloadAlerts(state: State, repo: String): Try[Seq[Vulnerability]] = {
-    val snapshotUrl = s"https://api.github.com/repos/$repo/dependabot/alerts"
+    val alertsUrl = s"https://api.github.com/repos/$repo/dependabot/alerts"
     val request =
-      Gigahorse.url(snapshotUrl).get.addHeaders("Authorization" -> s"token ${getGithubToken()}")
-    state.log.info(s"Downloading alerts from $snapshotUrl")
-    for {
-      httpResp <- Try(Await.result(http.processFull(request), Duration.Inf))
-      vulnerabilities <- getVulnerabilities(httpResp)
-    } yield {
-      state.log.info(s"Downloaded ${vulnerabilities.size} alerts")
-      vulnerabilities
-    }
+      Gigahorse.url(alertsUrl).get.addHeaders("Authorization" -> s"token ${getGithubToken()}")
+    state.log.info(s"Downloading alerts from $alertsUrl")
+
+    def attempt(): Try[Seq[Vulnerability]] =
+      for {
+        httpResp <- Try(Await.result(http.processFull(request), timeout))
+        vulnerabilities <- getVulnerabilities(httpResp)
+      } yield {
+        state.log.info(s"Downloaded ${vulnerabilities.size} alerts")
+        vulnerabilities
+      }
+
+    retryOnServerError(state.log)(attempt())
   }
 
   case class Vulnerability(
@@ -183,35 +189,38 @@ object AnalyzeDependencyGraph {
     }
   }
 
-  private def getVulnerabilities(httpResp: FullResponse): Try[Seq[Vulnerability]] = Try {
+  private[scala] def getVulnerabilities(httpResp: FullResponse): Try[Seq[Vulnerability]] =
     httpResp.status match {
       case status if status / 100 == 2 =>
-        val json: JArray = JsonParser.parseFromByteBuffer(httpResp.bodyAsByteBuffer).get.asInstanceOf[JArray]
-        json.value.collect {
-          case obj: JObject if obj.value.collectFirst { case JField("state", JString("open")) => true }.isDefined =>
-            val securityVulnerability =
-              obj.value.collectFirst { case JField("security_vulnerability", secVuln: JObject) => secVuln }.get.value
-            val packageObj =
-              securityVulnerability.collectFirst { case JField("package", pkg: JObject) => pkg }.get.value
-            val firstPatchedVersion = securityVulnerability
-              .collectFirst { case JField("first_patched_version", firstPatched: JObject) => firstPatched }
-              .map(_.value.collectFirst { case JField("identifier", JString(ident)) => ident }.getOrElse(""))
-              .getOrElse("")
-            Vulnerability(
-              packageObj.collectFirst { case JField("name", JString(name)) => name }.get,
-              securityVulnerability.collectFirst {
-                case JField("vulnerable_version_range", JString(range)) => range
-              }.get,
-              firstPatchedVersion,
-              securityVulnerability.collectFirst { case JField("severity", JString(sev)) => sev }.get
-            )
-        }.toSeq
-      case _ =>
+        Try {
+          val json: JArray = JsonParser.parseFromByteBuffer(httpResp.bodyAsByteBuffer).get.asInstanceOf[JArray]
+          json.value.collect {
+            case obj: JObject if obj.value.collectFirst { case JField("state", JString("open")) => true }.isDefined =>
+              val securityVulnerability =
+                obj.value.collectFirst { case JField("security_vulnerability", secVuln: JObject) => secVuln }.get.value
+              val packageObj =
+                securityVulnerability.collectFirst { case JField("package", pkg: JObject) => pkg }.get.value
+              val firstPatchedVersion = securityVulnerability
+                .collectFirst { case JField("first_patched_version", firstPatched: JObject) => firstPatched }
+                .map(_.value.collectFirst { case JField("identifier", JString(ident)) => ident }.getOrElse(""))
+                .getOrElse("")
+              Vulnerability(
+                packageObj.collectFirst { case JField("name", JString(name)) => name }.get,
+                securityVulnerability.collectFirst {
+                  case JField("vulnerable_version_range", JString(range)) => range
+                }.get,
+                firstPatchedVersion,
+                securityVulnerability.collectFirst { case JField("severity", JString(sev)) => sev }.get
+              )
+          }.toSeq
+        }
+      case status if status / 100 == 5 =>
+        Failure(ServerError(status, httpResp.statusText, httpResp.bodyAsString))
+      case status =>
         val message =
-          s"Unexpected status ${httpResp.status} ${httpResp.statusText} with body:\n${httpResp.bodyAsString}"
-        throw new MessageOnlyException(message)
+          s"Unexpected status $status ${httpResp.statusText} with body:\n${httpResp.bodyAsString}"
+        Failure(new MessageOnlyException(message))
     }
-  }
 
   private def githubToken(): String = Properties.envOrElse("GITHUB_TOKEN", "")
 }

--- a/sbt-plugin/src/main/scala/ch/epfl/scala/ApiCall.scala
+++ b/sbt-plugin/src/main/scala/ch/epfl/scala/ApiCall.scala
@@ -1,0 +1,41 @@
+package ch.epfl.scala
+
+import scala.concurrent.duration._
+import scala.util.Failure
+import scala.util.Try
+
+import sbt.Logger
+import sbt.internal.util.MessageOnlyException
+
+/** Support utilities for API calls. */
+object ApiCall {
+
+  val timeout: Duration = 30.seconds
+
+  private val maxRetries: Int = 3
+  private val retryBaseDelay: Duration = 4.seconds
+
+  /** An HTTP 5XX response. */
+  case class ServerError(status: Int, statusText: String, bodyAsString: String)
+      extends Exception(s"Unexpected status $status $statusText with body:\n$bodyAsString")
+
+  /**
+   * Retries `attempt` on a [[ServerError]], applying exponential back-off.
+   * Non-server errors are propagated immediately without retrying.
+   */
+  def retryOnServerError[A](
+      log: Logger,
+      retriesLeft: Int = maxRetries,
+      delay: Duration = retryBaseDelay
+  )(attempt: => Try[A]): Try[A] =
+    attempt.recoverWith {
+      case ServerError(status, statusText, _) if retriesLeft > 0 =>
+        log.warn(
+          s"API responded with $status ($statusText). Retrying in ${delay.toMillis}ms ($retriesLeft retries left)."
+        )
+        Thread.sleep(delay.toMillis)
+        retryOnServerError(log, retriesLeft - 1, delay * 2)(attempt)
+      case err @ ServerError(_, _, _) =>
+        Failure(new MessageOnlyException(err.getMessage))
+    }
+}

--- a/sbt-plugin/src/main/scala/ch/epfl/scala/SubmitDependencyGraph.scala
+++ b/sbt-plugin/src/main/scala/ch/epfl/scala/SubmitDependencyGraph.scala
@@ -4,10 +4,13 @@ import java.nio.file.Paths
 import java.time.Instant
 
 import scala.concurrent.Await
-import scala.concurrent.duration.Duration
+import scala.util.Failure
 import scala.util.Properties
 import scala.util.Try
 
+import ch.epfl.scala.ApiCall.ServerError
+import ch.epfl.scala.ApiCall.retryOnServerError
+import ch.epfl.scala.ApiCall.timeout
 import ch.epfl.scala.GithubDependencyGraphPlugin.autoImport._
 import ch.epfl.scala.JsonProtocol.{_, given}
 import ch.epfl.scala.githubapi.JsonProtocol.{_, given}
@@ -115,8 +118,9 @@ object SubmitDependencyGraph {
       )
 
     state.log.info(s"Submitting dependency snapshot of job $job to GitHub Dependency Graph API")
-    val result = for {
-      httpResp <- Try(Await.result(http.processFull(request), Duration.Inf))
+
+    def attempt(): Try[State] = for {
+      httpResp <- Try(Await.result(http.processFull(request), timeout))
       snapshot <- getSnapshot(httpResp)
     } yield {
       successMessages(snapshot.id, httpResp.bodyAsString).foreach(state.log.info(_))
@@ -124,7 +128,7 @@ object SubmitDependencyGraph {
       state
     }
 
-    result.get
+    retryOnServerError(state.log)(attempt()).get
   }
 
   private[scala] def successMessages(snapshotId: Long, responseBody: String): Seq[String] =
@@ -144,16 +148,18 @@ object SubmitDependencyGraph {
     for (output <- githubOutput())
       IO.writeLines(output, outputs.map { case (name, value) => s"${name}=${value}" }, append = true)
 
-  private def getSnapshot(httpResp: FullResponse): Try[SnapshotResponse] =
+  private[scala] def getSnapshot(httpResp: FullResponse): Try[SnapshotResponse] =
     httpResp.status match {
       case status if status / 100 == 2 =>
         JsonParser
           .parseFromByteBuffer(httpResp.bodyAsByteBuffer)
           .flatMap(Converter.fromJson[SnapshotResponse])
+      case status if status / 100 == 5 =>
+        Failure(ServerError(status, httpResp.statusText, httpResp.bodyAsString))
       case status =>
         val message =
           s"Unexpected status $status ${httpResp.statusText} with body:\n${httpResp.bodyAsString}"
-        throw new MessageOnlyException(message)
+        Failure(new MessageOnlyException(message))
     }
 
   private def githubDependencySnapshot(state: State, correlator: String): DependencySnapshot = {

--- a/sbt-plugin/src/test/scala/ch/epfl/scala/AnalyzeDependencyGraphTests.scala
+++ b/sbt-plugin/src/test/scala/ch/epfl/scala/AnalyzeDependencyGraphTests.scala
@@ -1,0 +1,44 @@
+package ch.epfl.scala
+
+import scala.util.Failure
+import scala.util.Success
+
+import ch.epfl.scala.AnalyzeDependencyGraph.getVulnerabilities
+import ch.epfl.scala.ApiCall.ServerError
+import munit.FunSuite
+
+class AnalyzeDependencyGraphTests extends FunSuite {
+
+  import TestStubs.stubResponse
+
+  private val emptyAlertsBody = "[]"
+
+  test("getVulnerabilities returns empty list on 200 with empty array") {
+    val resp = stubResponse(200, "OK", emptyAlertsBody)
+    assertEquals(getVulnerabilities(resp), Success(Seq.empty))
+  }
+
+  test("getVulnerabilities returns ServerError on 500") {
+    val resp = stubResponse(500, "Internal Server Error", "oops")
+    getVulnerabilities(resp) match {
+      case Failure(ServerError(500, "Internal Server Error", _)) => // expected
+      case other                                                 => fail(s"Unexpected result: $other")
+    }
+  }
+
+  test("getVulnerabilities returns ServerError on 503") {
+    val resp = stubResponse(503, "Service Unavailable", "")
+    getVulnerabilities(resp) match {
+      case Failure(ServerError(503, _, _)) => // expected
+      case other                           => fail(s"Unexpected result: $other")
+    }
+  }
+
+  test("getVulnerabilities returns failure on 4XX") {
+    val resp = stubResponse(401, "Unauthorized", "not allowed")
+    getVulnerabilities(resp) match {
+      case Failure(_: sbt.internal.util.MessageOnlyException) => // expected
+      case other                                              => fail(s"Unexpected result: $other")
+    }
+  }
+}

--- a/sbt-plugin/src/test/scala/ch/epfl/scala/ApiCallTests.scala
+++ b/sbt-plugin/src/test/scala/ch/epfl/scala/ApiCallTests.scala
@@ -1,0 +1,96 @@
+package ch.epfl.scala
+
+import scala.collection.mutable
+import scala.concurrent.duration._
+import scala.util.Failure
+import scala.util.Success
+
+import munit.FunSuite
+import sbt.Logger
+import sbt.internal.util.MessageOnlyException
+
+class ApiCallTests extends FunSuite {
+
+  import ApiCall.ServerError
+
+  /** Captures warn messages; all other log levels are no-ops. */
+  private def stubLog(warnings: mutable.Buffer[String]): Logger =
+    new Logger {
+      override def trace(t: => Throwable): Unit = ()
+      override def success(message: => String): Unit = ()
+      override def log(level: sbt.Level.Value, message: => String): Unit =
+        if (level == sbt.Level.Warn) warnings += message
+    }
+
+  test("retryOnServerError returns immediately on success") {
+    var callCount = 0
+    val warnings = mutable.Buffer.empty[String]
+    val result = ApiCall.retryOnServerError(stubLog(warnings), delay = Duration.Zero) {
+      callCount += 1
+      Success("ok")
+    }
+    assertEquals(result, Success("ok"))
+    assertEquals(callCount, 1)
+    assert(warnings.isEmpty)
+  }
+
+  test("retryOnServerError retries on 5XX and succeeds on second attempt") {
+    var callCount = 0
+    val warnings = mutable.Buffer.empty[String]
+    val result = ApiCall.retryOnServerError(stubLog(warnings), retriesLeft = 3, delay = Duration.Zero) {
+      callCount += 1
+      if (callCount == 1) Failure(ServerError(503, "Service Unavailable", "Error details"))
+      else Success("ok")
+    }
+    assertEquals(result, Success("ok"))
+    assertEquals(callCount, 2)
+    assertEquals(warnings.size, 1)
+    assert(warnings.head.contains("503"))
+  }
+
+  test("retryOnServerError exhausts retries and returns MessageOnlyException") {
+    var callCount = 0
+    val warnings = mutable.Buffer.empty[String]
+    val result = ApiCall.retryOnServerError(stubLog(warnings), retriesLeft = 2, delay = Duration.Zero) {
+      callCount += 1
+      Failure(ServerError(502, "Bad Gateway", "Error details"))
+    }
+    assert(result.isFailure)
+    assertEquals(callCount, 3) // initial attempt + 2 retries
+    assertEquals(warnings.size, 2)
+    result match {
+      case Failure(e: MessageOnlyException) => assert(e.getMessage.contains("502"))
+      case other                            => fail(s"Unexpected result: $other")
+    }
+  }
+
+  test("retryOnServerError does not retry on non-5XX failure") {
+    var callCount = 0
+    val warnings = mutable.Buffer.empty[String]
+    val err = new RuntimeException("client error")
+    val result = ApiCall.retryOnServerError(stubLog(warnings), delay = Duration.Zero) {
+      callCount += 1
+      Failure(err)
+    }
+    assertEquals(callCount, 1)
+    assert(warnings.isEmpty)
+    assertEquals(result, Failure(err))
+  }
+
+  test("retryOnServerError with zero retries returns MessageOnlyException immediately") {
+    var callCount = 0
+    val result = ApiCall.retryOnServerError(
+      stubLog(mutable.Buffer.empty),
+      retriesLeft = 0,
+      delay = Duration.Zero
+    ) {
+      callCount += 1
+      Failure(ServerError(503, "Service Unavailable", "Error details"))
+    }
+    assertEquals(callCount, 1)
+    result match {
+      case Failure(e: MessageOnlyException) => assert(e.getMessage.contains("503"))
+      case other                            => fail(s"Unexpected result: $other")
+    }
+  }
+}

--- a/sbt-plugin/src/test/scala/ch/epfl/scala/SubmitDependencyGraphTests.scala
+++ b/sbt-plugin/src/test/scala/ch/epfl/scala/SubmitDependencyGraphTests.scala
@@ -1,5 +1,10 @@
 package ch.epfl.scala
 
+import scala.util.Failure
+import scala.util.Success
+
+import ch.epfl.scala.ApiCall.ServerError
+import ch.epfl.scala.SubmitDependencyGraph.getSnapshot
 import ch.epfl.scala.SubmitDependencyGraph.successMessages
 import ch.epfl.scala.SubmitDependencyGraph.successOutputs
 import munit.FunSuite
@@ -42,5 +47,32 @@ class SubmitDependencyGraphTests extends FunSuite {
         "submission-api-url" -> "https://api.github.com/repos/foo/bar/dependency-graph/snapshots/123"
       )
     )
+  }
+
+  import TestStubs.stubResponse
+
+  test("getSnapshot parses a valid 2XX response") {
+    val body = """{"id":42,"created_at":"2024-05-31T00:11:22.957Z","result":"ACCEPTED","message":"ok"}"""
+    val resp = stubResponse(201, "Created", body)
+    getSnapshot(resp) match {
+      case Success(snapshot) => assertEquals(snapshot.id, 42)
+      case other             => fail(s"Unexpected result: $other")
+    }
+  }
+
+  test("getSnapshot returns ServerError on 5XX") {
+    val resp = stubResponse(503, "Service Unavailable", "")
+    getSnapshot(resp) match {
+      case Failure(ServerError(503, _, _)) => // expected
+      case other                           => fail(s"Unexpected result: $other")
+    }
+  }
+
+  test("getSnapshot returns failure on 4XX") {
+    val resp = stubResponse(403, "Forbidden", "denied")
+    getSnapshot(resp) match {
+      case Failure(_: sbt.internal.util.MessageOnlyException) => // expected
+      case other                                              => fail(s"Unexpected result: $other")
+    }
   }
 }

--- a/sbt-plugin/src/test/scala/ch/epfl/scala/TestStubs.scala
+++ b/sbt-plugin/src/test/scala/ch/epfl/scala/TestStubs.scala
@@ -1,0 +1,20 @@
+package ch.epfl.scala
+
+import gigahorse.FullResponse
+
+object TestStubs {
+
+  /** Minimal FullResponse stub for testing HTTP response handling. */
+  def stubResponse(statusCode: Int, statusMsg: String, body: String): FullResponse =
+    new FullResponse {
+      override def status: Int = statusCode
+      override def statusText: String = statusMsg
+      override def allHeaders: Map[String, List[String]] = Map.empty
+      override def header(key: String): Option[String] = None
+      override def underlying[A]: A = throw new UnsupportedOperationException
+      override def close(): Unit = ()
+      override def bodyAsString: String = body
+      override def bodyAsByteBuffer: java.nio.ByteBuffer =
+        java.nio.ByteBuffer.wrap(body.getBytes("UTF-8"))
+    }
+}


### PR DESCRIPTION
Occasionally the GitHub API calls made by this action fail but they generally work on the second attempt if retried manually. 

This change automates that retry to make the action more resilient.

The retry has been hardcoded to 3 attempts with an initial delay of 4s and an exponential backoff.
The number of retries and base delay duration could of course be parameterised as action inputs in a subsequent PR if this idea seems acceptable.

Tested by running the [test-action](https://github.com/scalacenter/sbt-dependency-submission/blob/1cc96a7038ea2b014c200c1dae3a0cc92293b91d/.github/workflows/ci.yml#L59) workflow job.
