### PR TITLE
Fix cross-version dependency submission with sbt 2

### DIFF
--- a/sbt-plugin/src/main/scala-2/ch/epfl/scala/ScalaVersionSwitchCompat.scala
+++ b/sbt-plugin/src/main/scala-2/ch/epfl/scala/ScalaVersionSwitchCompat.scala
@@ -1,0 +1,7 @@
+package ch.epfl.scala
+
+private[scala] object ScalaVersionSwitchCompat {
+  // sbt 1 switches every project with the same Scala binary version when it
+  // receives an exact version.
+  def selector(scalaVersion: String): String = scalaVersion
+}

--- a/sbt-plugin/src/main/scala-3/ch/epfl/scala/ScalaVersionSwitchCompat.scala
+++ b/sbt-plugin/src/main/scala-3/ch/epfl/scala/ScalaVersionSwitchCompat.scala
@@ -1,0 +1,11 @@
+package ch.epfl.scala
+
+import sbt.CrossVersion
+
+private[scala] object ScalaVersionSwitchCompat {
+  // sbt 2 switches only projects whose crossScalaVersions match its semantic
+  // selector. Select the binary series so project dependencies using another
+  // compatible compiler version are switched as well.
+  def selector(scalaVersion: String): String =
+    s"${CrossVersion.binaryScalaVersion(scalaVersion)}.x"
+}

--- a/sbt-plugin/src/main/scala/ch/epfl/scala/SubmitDependencyGraph.scala
+++ b/sbt-plugin/src/main/scala/ch/epfl/scala/SubmitDependencyGraph.scala
@@ -77,8 +77,16 @@ object SubmitDependencyGraph {
       .put(githubManifestsKey, Map.empty[String, Manifest])
       .put(githubProjectsKey, projectRefs)
 
-    val storeAllManifests = scalaVersions.flatMap { scalaVersion =>
-      Seq(s"++$scalaVersion", s"Global/${githubStoreDependencyManifests.key} $scalaVersion")
+    val scalaVersionsWithSelectors =
+      scalaVersions.map(scalaVersion => scalaVersion -> ScalaVersionSwitchCompat.selector(scalaVersion))
+    val storeAllManifests = scalaVersionsWithSelectors.map(_._2).distinct.flatMap { selector =>
+      val storeManifests = scalaVersionsWithSelectors
+        .filter(_._2 == selector)
+        .map {
+          case (scalaVersion, _) =>
+            s"Global/${githubStoreDependencyManifests.key} $scalaVersion"
+        }
+      s"++$selector" +: storeManifests
     }
     val commands = storeAllManifests :+ GenerateInternal
     commands.toList ::: initState

--- a/sbt-plugin/src/sbt-test/generate-snapshot/generate-snapshot/build.sbt
+++ b/sbt-plugin/src/sbt-test/generate-snapshot/generate-snapshot/build.sbt
@@ -13,6 +13,20 @@ inThisBuild(
   )
 )
 
+// The application and its library deliberately use different patch versions
+// for each Scala binary version. They must still be switched together before
+// resolving the application's dependency graph.
+val library = project
+  .in(file("library"))
+  .settings(
+    scalaVersion := "2.13.9",
+    crossScalaVersions := Seq(
+      "2.12.17",
+      "2.13.9",
+      "3.1.2"
+    )
+  )
+
 val a = project
   .in(file("."))
   .settings(
@@ -30,6 +44,7 @@ val a = project
         .classifier("natives-macos")
     )
   )
+  .dependsOn(library)
 
 // b is not cross-compiled
 // but we should still be able to resolve the manifests of the build on 2.12.16 and 3.1.3

--- a/sbt-plugin/src/sbt-test/generate-snapshot/generate-snapshot/test
+++ b/sbt-plugin/src/sbt-test/generate-snapshot/generate-snapshot/test
@@ -1,11 +1,11 @@
 > 'githubGenerateSnapshot {}'
-> Global / checkManifests 4
+> Global / checkManifests 7
 
 > 'githubGenerateSnapshot {"ignoredModules":["a_2.13", "b_2.13"]}'
-> Global / checkManifests 2
+> Global / checkManifests 5
 
 > 'githubGenerateSnapshot {"ignoredModules":["a_2.12", "a_2.13", "b_2.13"]}'
-> Global / checkManifests 1
+> Global / checkManifests 4
 
 > 'githubGenerateSnapshot {"ignoredModules":[]}'
-> Global / checkManifests 4
+> Global / checkManifests 7


### PR DESCRIPTION
Fix dependency snapshot generation for sbt 2 builds whose project dependencies use different compatible Scala compiler versions.

The plugin currently collects exact `crossScalaVersions` and runs `++` for each version. sbt 1 switches every project with the same Scala binary version, but sbt 2 treats the argument as a semantic selector and switches only projects matching that exact version.

This can leave a project on Scala 3 while one of its project dependencies remains on Scala 2.13, causing sbt 2 to reject the dependency with a Scala version mismatch.

For sbt 2, switch projects using binary-series selectors such as `++2.13.x` and `++3.x`. Continue using the exact versions when selecting the manifests to store. Preserve the existing sbt 1 behavior.

Added scripted coverage for project dependencies using different compatible Scala patch versions.